### PR TITLE
Add missing semicolon

### DIFF
--- a/msk.c
+++ b/msk.c
@@ -129,7 +129,7 @@ void demodMSK(channel_t *ch, int len)
 				ch->MskDphi = ch->MskDf + PLLKp * dphi;
 			}
 			else	// otherwise don't even try to lock. XXX REVISIT: use a 2nd order / 1st order PLL split?
-				ch->MskDf = ch->MskDphi = 0
+				ch->MskDf = ch->MskDphi = 0;
 		}
 
 		/* VCO */


### PR DESCRIPTION
It no longer compiles after this commit: https://github.com/f00b4r0/acarsdec/commit/d36d8227fa2d1b8d9e11b67fade7aafb77d6fb83
The cause is a missing semicolon in msk.c, line 132