### PR TITLE
Add Airspy R2 support by an arbitrary input rate channelizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ DESTPARAMS are:
  -p <ppm>		set ppm frequency correction (default: 0)
 ```
 
-#### Airspy Mini (R2 is currently not supported)
+#### Airspy Mini/R2
 
 ```
  --airspy <device>	decode from airspy dongle number <device> or hex serial <device>

--- a/acarsdec.h
+++ b/acarsdec.h
@@ -105,6 +105,9 @@ typedef struct {
 	float complex *restrict oscillator;	// scaled oversampled INTRATE oscillator
 	float *restrict dm_buffer;		// INTRATE-sampled signal magnitude buffer
 	float complex *restrict inb;		// oversampled bit circular buffer
+	float complex mix_phase;		// arbitrary-rate SDR NCO state
+	float complex mix_step;			// arbitrary-rate SDR NCO increment
+	unsigned int mix_count;			// arbitrary-rate SDR NCO renormalization counter
 	float MskPhi;				// MSK oscillator phase
 	float MskDphi;				// MSK oscillator phase offset
 	float MskDf;				// MSK oscillator phase offset integral

--- a/air.c
+++ b/air.c
@@ -234,7 +234,7 @@ int initAirspy(char *optarg)
 	}
 	vprerr("Set freq. to %d hz\n", Fc);
 
-	result = channels_init_sdr_rate(Fc, AIRINRATE, 1.0F);
+	result = channels_init_sdr_resample(Fc, AIRINRATE, 1.0F);
 	if (result)
 		goto fail;
 

--- a/air.c
+++ b/air.c
@@ -87,6 +87,7 @@ int initAirspy(char *optarg)
 	uint64_t airspy_serial = 0;
 	int airspy_device_count = 0;
 	uint64_t *airspy_device_list = NULL;
+	uint32_t required_rate;
 
 	if (!R.gain)
 		R.gain = 18;
@@ -183,27 +184,23 @@ int initAirspy(char *optarg)
 
 	airspy_get_samplerates(device, supported_samplerates, count);
 	int use_samplerate_index = -1;
+	required_rate = (R.maxFc - R.minFc) + 4 * INTRATE;
 	for (i = 0; i < count; i++) {
 		uint32_t new_rate = supported_samplerates[i];
-		uint32_t new_mult = new_rate / INTRATE;
-		if ((new_mult * INTRATE) == new_rate) {
-			// new_rate is usable if it's a divisible by INTRATE
-			if (use_samplerate_index == -1 || new_rate < AIRINRATE) {
-				// use new_rate if we don't have a rate set yet or if it's lower than the other one
-				// for airspy mini this is just gonna end up being 3 MSPS which should be sufficient
-				// airspy R2 has rates 2.5 and 10 MSPS which both aren't divisable so it's not
-				// usable with 12 kHz INTRATE
-				AIRINRATE = new_rate;
-				AIRMULT = new_mult;
-				use_samplerate_index = i;
-			}
+		if (new_rate < required_rate)
+			continue;
+		if (use_samplerate_index == -1 || new_rate < AIRINRATE) {
+			AIRINRATE = new_rate;
+			AIRMULT = new_rate / INTRATE;
+			use_samplerate_index = i;
 		}
 	}
 
 	free(supported_samplerates);
 
 	if (use_samplerate_index == -1) {
-		fprintf(stderr, ERRPFX "did not find suitable sampling rate\n");
+		fprintf(stderr, ERRPFX "did not find suitable sampling rate for %.3f MHz span\n",
+			((R.maxFc - R.minFc) + 4 * INTRATE) / 1000000.0);
 		goto fail;
 	}
 
@@ -216,7 +213,9 @@ int initAirspy(char *optarg)
 	}
 
 	/* enable packed samples */
-	airspy_set_packing(device, 1);
+	result = airspy_set_packing(device, 1);
+	if (result != AIRSPY_SUCCESS)
+		fprintf(stderr, WARNPFX "airspy_set_packing() failed: %s (%d)\n", airspy_error_name(result), result);
 
 	result = airspy_set_rf_bias(device, (uint8_t) R.bias);
 	if (result != AIRSPY_SUCCESS)
@@ -226,7 +225,7 @@ int initAirspy(char *optarg)
 	if (result != AIRSPY_SUCCESS)
 		fprintf(stderr, WARNPFX "airspy_set_linearity_gain() failed: %s (%d)\n", airspy_error_name(result), result);
 
-	Fc = find_centerfreq(R.minFc, R.maxFc, AIRMULT);
+	Fc = find_centerfreq_rate(R.minFc, R.maxFc, AIRINRATE);
 	if (!Fc)
 		goto fail;
 
@@ -237,7 +236,7 @@ int initAirspy(char *optarg)
 	}
 	vprerr("Set freq. to %d hz\n", Fc);
 
-	result = channels_init_sdr(Fc, AIRMULT, 1.0F);
+	result = channels_init_sdr_rate(Fc, AIRINRATE, 1.0F);
 	if (result)
 		goto fail;
 
@@ -250,7 +249,7 @@ fail:
 
 static int rx_callback(airspy_transfer_t *transfer)
 {
-	channels_mix_phasors(transfer->samples, transfer->sample_count, AIRMULT);
+	channels_mix_phasors_rate(transfer->samples, transfer->sample_count, AIRINRATE);
 	return 0;
 }
 

--- a/air.c
+++ b/air.c
@@ -32,7 +32,6 @@
 #define ERRPFX	"ERROR: AIRSPY: "
 #define WARNPFX	"WARNING: AIRSPY: "
 
-static unsigned int AIRMULT;
 static unsigned int AIRINRATE;
 
 static struct airspy_device *device = NULL;
@@ -191,7 +190,6 @@ int initAirspy(char *optarg)
 			continue;
 		if (use_samplerate_index == -1 || new_rate < AIRINRATE) {
 			AIRINRATE = new_rate;
-			AIRMULT = new_rate / INTRATE;
 			use_samplerate_index = i;
 		}
 	}
@@ -200,7 +198,7 @@ int initAirspy(char *optarg)
 
 	if (use_samplerate_index == -1) {
 		fprintf(stderr, ERRPFX "did not find suitable sampling rate for %.3f MHz span\n",
-			((R.maxFc - R.minFc) + 4 * INTRATE) / 1000000.0);
+		       (required_rate / 1000000.0));
 		goto fail;
 	}
 
@@ -249,7 +247,7 @@ fail:
 
 static int rx_callback(airspy_transfer_t *transfer)
 {
-	channels_mix_phasors_rate(transfer->samples, transfer->sample_count, AIRINRATE);
+	channels_mix_phasors_resample(transfer->samples, transfer->sample_count, AIRINRATE);
 	return 0;
 }
 

--- a/lib.c
+++ b/lib.c
@@ -114,7 +114,7 @@ int channels_init_sdr(unsigned int Fc, unsigned int multiplier, float scale)
 	return 0;
 }
 
-int channels_init_sdr_rate(unsigned int Fc, unsigned int input_rate, float scale)
+int channels_init_sdr_resample(unsigned int Fc, unsigned int input_rate, float scale)
 {
 	unsigned int n;
 	float scale_factor;

--- a/lib.c
+++ b/lib.c
@@ -243,6 +243,25 @@ void channels_mix_phasors(const float complex *restrict phasors, unsigned int le
 	}
 }
 
+/**
+ * This function handles sample rates that are not clean integer multiples 
+ * of 12 kHz, specifically for the AirSpy R2 which has rates of 2.5MS/s and
+ * 10 MS/s. It breaks out the mixer phase and 12 khZ output timing 
+ * explicitly. Similar to the channels_mix_phasors_rate function, once enough
+ * data has been processed, the samples are sent to the push and demod function.
+ *
+ * The mix_phase is periodically renormalized to prevent small floating
+ * point errors from building up and destroying the signal.  
+ *
+ * In plain terms, it takes the channel to baseband, one input sample at
+ * a time. While doing that, enough shifted samples are added to produce
+ * a single output sample at the decoder rate, then passed to the demod, which
+ * stores magnitude and eventually feeds the MSK demod.
+ *
+ * @param phasors An array of input I/Q samples from the SDR
+ * @param len The number of complex samples in the array.
+ * @param input_rate The sample rate in samples per second.
+ */
 void channels_mix_phasors_resample(const float complex *restrict phasors, unsigned int len, unsigned int input_rate)
 {
 	static float complex *restrict D = NULL;
@@ -254,12 +273,14 @@ void channels_mix_phasors_resample(const float complex *restrict phasors, unsign
 		return;
 
 	if (unlikely(!D)) {
+		// Allocate one accumlator per channel
 		D = calloc(nbch, sizeof(*D));
 		if (!D)
 			err(EX_OSERR, NULL);
 	}
 
 	for (i = 0; i < len; i++) {
+		// Process one i/q sample at the device sample rate.
 		float complex sample = phasors[i];
 
 		for (n = 0; n < nbch; n++) {
@@ -267,27 +288,41 @@ void channels_mix_phasors_resample(const float complex *restrict phasors, unsign
 			float complex mixed;
 			float phase_mag;
 
+			// Shift this channel from its RF offset down to baseband
+			// and add the result into the current output accumulator.
 			mixed = sample * ch->mix_phase;
+
+// The below can be used to debug if the renormalization isn't working
+// correctly or if the data is bad (the sample is NaN or inf). 
+#if defined(DEBUG)
 			if (!isfinite(crealf(mixed)) || !isfinite(cimagf(mixed))) {
 				vprerr("WARNING: MIX: resetting non-finite mixed sample on channel #%u\n", n + 1);
 				ch->mix_phase = cabsf(ch->mix_phase) > 0.0F ? ch->mix_phase / cabsf(ch->mix_phase) * ((float)INTRATE / (float)input_rate) : ((float)INTRATE / (float)input_rate);
 				ch->mix_count = 0;
 				mixed = 0.0F;
 			}
+#endif
 			D[n] += mixed;
+
+			// Advance the oscillator so the next sample uses the correct
+			// phase for this channels frequency offset.
 			ch->mix_phase *= ch->mix_step;
+
+			// Every MIX_RENORM_INTERVAL, renormalize the phase magnitude, preventing
+			// drift towards zero/infinity. Floating point roundoff can slowly change
+			// the magnitude of mix_phase. This keeps the oscillator stable. Prior to
+			// implementing this check, after several minutes of runtime, the mix_phase
+			// could/would trend towards zero/inf.
 			if ((++ch->mix_count & (MIX_RENORM_INTERVAL - 1U)) == 0) {
 				phase_mag = cabsf(ch->mix_phase);
-				if (!isfinite(phase_mag) || phase_mag == 0.0F) {
-					vprerr("WARNING: MIX: resetting invalid NCO state on channel #%u\n", n + 1);
-					ch->mix_phase = ((float)INTRATE / (float)input_rate);
-				} else {
-					ch->mix_phase /= phase_mag;
-					ch->mix_phase *= ((float)INTRATE / (float)input_rate);
-				}
+				ch->mix_phase /= phase_mag;
+				ch->mix_phase *= ((float)INTRATE / (float)input_rate);
 			}
 		}
 
+		// Convert the arbitrary rate into a steady 12kHz output,
+		// and when enough has accumulated, emit a decoder-rate
+		// sample to the demodulator.
 		phase_acc += INTRATE;
 		if (phase_acc >= input_rate) {
 			phase_acc -= input_rate;

--- a/lib.c
+++ b/lib.c
@@ -32,6 +32,8 @@
  #include "soundfile.h"
 #endif
 
+#define MIX_RENORM_INTERVAL 1024U
+
 /**
  * Return the minimum sample rate multiplier suitable to cover the target frequency range.
  * @param minFc lowest frequency in the range
@@ -56,6 +58,19 @@ unsigned int find_centerfreq(unsigned int minFc, unsigned int maxFc, unsigned in
 
 	// the original tried to pin the center frequency to one of the provided ACARS freqs
 	// there is no reason to do this (and in fact it's better to avoid the DC spike), so keep this simple:
+	return (maxFc + minFc) / 2;
+}
+
+unsigned int find_centerfreq_rate(unsigned int minFc, unsigned int maxFc, unsigned int input_rate)
+{
+	if (R.Fc)
+		return R.Fc;
+
+	if ((maxFc - minFc) > input_rate - 4 * INTRATE) {
+		fprintf(stderr, "Frequencies too far apart\n");
+		return 0;
+	}
+
 	return (maxFc + minFc) / 2;
 }
 
@@ -88,6 +103,38 @@ int channels_init_sdr(unsigned int Fc, unsigned int multiplier, float scale)
 		       n+1, Fc, ch->Fr, correctionPhase, (signed)(ch->Fr - Fc));
 		for (ind = 0; ind < multiplier; ind++)
 			ch->oscillator[ind] = cexpf(correctionPhase * ind * -I) / multiplier / scale;
+	}
+
+	return 0;
+}
+
+int channels_init_sdr_rate(unsigned int Fc, unsigned int input_rate, float scale)
+{
+	unsigned int n;
+	float scale_factor;
+
+	if (!input_rate)
+		return 1;
+
+	scale_factor = ((float)INTRATE / (float)input_rate) / scale;
+
+	for (n = 0; n < R.nbch; n++) {
+		channel_t *ch = &R.channels[n];
+		float correctionPhase;
+
+		ch->dm_buffer = malloc(DMBUFSZ * sizeof(*ch->dm_buffer));
+		if (ch->dm_buffer == NULL) {
+			perror(NULL);
+			return 1;
+		}
+
+		correctionPhase = (signed)(ch->Fr - Fc) / (float)input_rate * (float)(2 * M_PI);
+		vprerr("#%d: Fc = %uHz, Fr = %uHz, phase = % f (%+dHz)\n",
+		       n + 1, Fc, ch->Fr, correctionPhase, (signed)(ch->Fr - Fc));
+
+		ch->mix_phase = scale_factor;
+		ch->mix_step = cexpf(correctionPhase * -I);
+		ch->mix_count = 0;
 	}
 
 	return 0;
@@ -187,5 +234,58 @@ void channels_mix_phasors(const float complex *restrict phasors, unsigned int le
 			ind = lim;
 		len -= lim;
 		phasors += lim;
+	}
+}
+
+void channels_mix_phasors_rate(const float complex *restrict phasors, unsigned int len, unsigned int input_rate)
+{
+	static float complex *restrict D = NULL;
+	static unsigned int phase_acc = 0;
+	const unsigned int nbch = R.nbch;
+	unsigned int i, n;
+
+	if (unlikely(!len || !input_rate))
+		return;
+
+	if (unlikely(!D)) {
+		D = calloc(nbch, sizeof(*D));
+		if (!D)
+			err(EX_OSERR, NULL);
+	}
+
+	for (i = 0; i < len; i++) {
+		float complex sample = phasors[i];
+
+		for (n = 0; n < nbch; n++) {
+			channel_t *ch = &R.channels[n];
+			float complex mixed;
+			float phase_mag;
+
+			mixed = sample * ch->mix_phase;
+			if (!isfinite(crealf(mixed)) || !isfinite(cimagf(mixed))) {
+				vprerr("WARNING: MIX: resetting non-finite mixed sample on channel #%u\n", n + 1);
+				ch->mix_phase = cabsf(ch->mix_phase) > 0.0F ? ch->mix_phase / cabsf(ch->mix_phase) * ((float)INTRATE / (float)input_rate) : ((float)INTRATE / (float)input_rate);
+				ch->mix_count = 0;
+				mixed = 0.0F;
+			}
+			D[n] += mixed;
+			ch->mix_phase *= ch->mix_step;
+			if ((++ch->mix_count & (MIX_RENORM_INTERVAL - 1U)) == 0) {
+				phase_mag = cabsf(ch->mix_phase);
+				if (!isfinite(phase_mag) || phase_mag == 0.0F) {
+					vprerr("WARNING: MIX: resetting invalid NCO state on channel #%u\n", n + 1);
+					ch->mix_phase = ((float)INTRATE / (float)input_rate);
+				} else {
+					ch->mix_phase /= phase_mag;
+					ch->mix_phase *= ((float)INTRATE / (float)input_rate);
+				}
+			}
+		}
+
+		phase_acc += INTRATE;
+		if (phase_acc >= input_rate) {
+			phase_acc -= input_rate;
+			channels_push_and_demod_sample(D);
+		}
 	}
 }

--- a/lib.c
+++ b/lib.c
@@ -247,7 +247,7 @@ void channels_mix_phasors(const float complex *restrict phasors, unsigned int le
  * This function handles sample rates that are not clean integer multiples 
  * of 12 kHz, specifically for the AirSpy R2 which has rates of 2.5MS/s and
  * 10 MS/s. It breaks out the mixer phase and 12 khZ output timing 
- * explicitly. Similar to the channels_mix_phasors_rate function, once enough
+ * explicitly. Similar to the channels_mix_phasors function, once enough
  * data has been processed, the samples are sent to the push and demod function.
  *
  * The mix_phase is periodically renormalized to prevent small floating

--- a/lib.c
+++ b/lib.c
@@ -32,6 +32,12 @@
  #include "soundfile.h"
 #endif
 
+/**
+ * Interval defines how often the arbitrary rate remixer renormalizes the
+ * channel state. This prevents the complex multiplies from drifting in
+ * magnitude over time. As a power of two, it allows use of an bit op rather
+ * than a modulo.
+ */
 #define MIX_RENORM_INTERVAL 1024U
 
 /**
@@ -237,7 +243,7 @@ void channels_mix_phasors(const float complex *restrict phasors, unsigned int le
 	}
 }
 
-void channels_mix_phasors_rate(const float complex *restrict phasors, unsigned int len, unsigned int input_rate)
+void channels_mix_phasors_resample(const float complex *restrict phasors, unsigned int len, unsigned int input_rate)
 {
 	static float complex *restrict D = NULL;
 	static unsigned int phase_acc = 0;

--- a/lib.h
+++ b/lib.h
@@ -26,6 +26,6 @@ unsigned int find_centerfreq_rate(unsigned int minFc, unsigned int maxFc, unsign
 int channels_init_sdr(unsigned int Fc, unsigned int multiplier, float scale);
 void channels_mix_phasors(const float complex *phasors, unsigned int len, const unsigned int multiplier);
 int channels_init_sdr_rate(unsigned int Fc, unsigned int input_rate, float scale);
-void channels_mix_phasors_rate(const float complex *phasors, unsigned int len, unsigned int input_rate);
+void channels_mix_phasors_resample(const float complex *phasors, unsigned int len, unsigned int input_rate);
 
 #endif /* lib_h */

--- a/lib.h
+++ b/lib.h
@@ -25,7 +25,7 @@ unsigned int find_centerfreq(unsigned int minFc, unsigned int maxFc, unsigned in
 unsigned int find_centerfreq_rate(unsigned int minFc, unsigned int maxFc, unsigned int input_rate);
 int channels_init_sdr(unsigned int Fc, unsigned int multiplier, float scale);
 void channels_mix_phasors(const float complex *phasors, unsigned int len, const unsigned int multiplier);
-int channels_init_sdr_rate(unsigned int Fc, unsigned int input_rate, float scale);
+int channels_init_sdr_resample(unsigned int Fc, unsigned int input_rate, float scale);
 void channels_mix_phasors_resample(const float complex *phasors, unsigned int len, unsigned int input_rate);
 
 #endif /* lib_h */

--- a/lib.h
+++ b/lib.h
@@ -22,7 +22,10 @@
 
 unsigned int min_multiplier(unsigned int minFc, unsigned int maxFc);
 unsigned int find_centerfreq(unsigned int minFc, unsigned int maxFc, unsigned int multiplier);
+unsigned int find_centerfreq_rate(unsigned int minFc, unsigned int maxFc, unsigned int input_rate);
 int channels_init_sdr(unsigned int Fc, unsigned int multiplier, float scale);
 void channels_mix_phasors(const float complex *phasors, unsigned int len, const unsigned int multiplier);
+int channels_init_sdr_rate(unsigned int Fc, unsigned int input_rate, float scale);
+void channels_mix_phasors_rate(const float complex *phasors, unsigned int len, unsigned int input_rate);
 
 #endif /* lib_h */


### PR DESCRIPTION
Also adjust sample-rate selection to only require enough bandwidth for the requested span.