### PR TITLE
Fix off-by-one in text buffer boundary check and filename buffer underallocation

### DIFF
--- a/acars.c
+++ b/acars.c
@@ -364,7 +364,9 @@ synced:
 		break;	// else fail
 
 	case TXT:
-		if (unlikely(ch->blk->txtlen > TXTMAXLEN)) {
+		// Use >= so that txtlen == TXTMAXLEN is caught before writing to
+		// txt.raw[TXTMAXLEN], which is one past the end of the buffer.
+		if (unlikely(ch->blk->txtlen >= TXTMAXLEN)) {
 			vprerr("#%d too long\n", ch->chn + 1);
 			break;	// fail
 		}

--- a/fileout.c
+++ b/fileout.c
@@ -56,12 +56,14 @@ static FILE *open_outfile(fileout_t *fout)
 			vprerr(ERRPFX "open_outfile(): strfime returned 0\n");
 			return NULL;
 		}
-		filename = malloc(fout->prefix_len + tlen + 2);
+		size_t ext_len = fout->extension ? strlen(fout->extension) : 0;
+		size_t filename_len = fout->prefix_len + tlen + ext_len + 1;
+		filename = malloc(filename_len);
 		if (filename == NULL) {
 			perror(ERRPFX "open_outfile()");
 			return NULL;
 		}
-		sprintf(filename, "%s%s%s", fout->filename_prefix, suffix, fout->extension ? fout->extension : "");
+		snprintf(filename, filename_len, "%s%s%s", fout->filename_prefix, suffix, fout->extension ? fout->extension : "");
 	} else {
 		filename = strdup(fout->filename_prefix);
 	}


### PR DESCRIPTION
Two independent bug fixes:

**acars.c — off-by-one in text buffer boundary check**
The condition `blk->txtlen > TXTMAXLEN` allowed a write to
`txt.raw[TXTMAXLEN]`, one byte past the end of the buffer, before the
check fired. Changed to `>= TXTMAXLEN` so the boundary is caught before
the out-of-bounds write occurs.

**fileout.c — filename buffer underallocation**
`malloc(prefix_len + tlen + 2)` did not include the length of the file
extension string. For any extension longer than one character (e.g. `.log`
= 4 bytes) this allocated a buffer too small for the subsequent sprintf,
causing a heap buffer overflow. Fixed by computing `ext_len` explicitly
and using `snprintf` with the correctly sized allocation.
