### PR TITLE
fix typo in SDRPlay device logic for bias, stub RSPdxR2 with API 3.14

### DIFF
--- a/sdrplay.c
+++ b/sdrplay.c
@@ -28,6 +28,12 @@
 #include "lib.h"
 #include <sdrplay_api.h>
 
+
+// SDRPlay API 3.14
+#ifndef SDRPLAY_RSPdxR2_ID
+#define SDRPLAY_RSPdxR2_ID (SDRPLAY_RSPdx_ID)
+#endif
+
 // choose 252 as the 12k (INTRATE) multiplier because 12k * 252 = 3024Msps
 // (which is reasonable)
 // the specific reason for 252 is that the SDRplay API RX callback size
@@ -247,7 +253,7 @@ int initSdrplay(char *optarg)
 	}
 
 	if (R.bias) {
-		if (device.hwVer == SDRPLAY_RSP1A_ID || SDRPLAY_RSP1B_ID) {
+		if (device.hwVer == SDRPLAY_RSP1A_ID || device.hwVer == SDRPLAY_RSP1B_ID) {
 			rx_channel_params->rsp1aTunerParams.biasTEnable = R.bias;
 		} else if (device.hwVer == SDRPLAY_RSP2_ID) {
 			rx_channel_params->rsp2TunerParams.biasTEnable = R.bias;


### PR DESCRIPTION
fixes #23 by fixing the typo and aliasing `SDRPLAY_RSPdxR2_ID` in case it isn't defined. 

```
build % cmake ..
-- The C compiler identification is AppleClang 16.0.0.16000026
...
-- Using sdrplay_api: YES
...
-- Generating done (0.0s)
-- Build files have been written to: .../acarsdec/build
```

```
build % make
[  7%] Building C object CMakeFiles/acarsdec.dir/acars.c.o
[ 14%] Building C object CMakeFiles/acarsdec.dir/acarsdec.c.o
...
[ 85%] Building C object CMakeFiles/acarsdec.dir/sdrplay.c.o
[ 92%] Building C object CMakeFiles/acarsdec.dir/soapy.c.o
[100%] Linking C executable acarsdec
[100%] Built target acarsdec
```

macOS 14.8